### PR TITLE
Slack Object

### DIFF
--- a/app/models/slack_object.rb
+++ b/app/models/slack_object.rb
@@ -1,0 +1,2 @@
+class SlackObject < ActiveRecord::Base
+end

--- a/db/migrate/20150830195509_create_slack_objects.rb
+++ b/db/migrate/20150830195509_create_slack_objects.rb
@@ -1,0 +1,15 @@
+class CreateSlackObjects < ActiveRecord::Migration
+  def change
+    create_table :slack_objects do |t|
+      t.string :user_id
+      t.string :user_name
+      t.string :team_id
+      t.string :team_domain
+      t.string :channel_id
+      t.string :channel_name
+
+      t.timestamps null: false
+    end
+    add_index :slack_objects, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150830195509) do
+
+  create_table "slack_objects", force: :cascade do |t|
+    t.string   "user_id"
+    t.string   "user_name"
+    t.string   "team_id"
+    t.string   "team_domain"
+    t.string   "channel_id"
+    t.string   "channel_name"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "slack_objects", ["user_id"], name: "index_slack_objects_on_user_id"
+
+end

--- a/test/fixtures/slack_objects.yml
+++ b/test/fixtures/slack_objects.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: MyString
+  user_name: MyString
+  team_id: MyString
+  team_domain: MyString
+  channel_id: MyString
+  channel_name: MyString
+
+two:
+  user_id: MyString
+  user_name: MyString
+  team_id: MyString
+  team_domain: MyString
+  channel_id: MyString
+  channel_name: MyString

--- a/test/models/slack_object_test.rb
+++ b/test/models/slack_object_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SlackObjectTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
See https://api.slack.com/slash-commands for a full description of POST data.

`
token=gIkuvaNzQIHg97ATvDxqgjtO
team_id=T0001
team_domain=example
channel_id=C2147483705
channel_name=test
user_id=U2147483697
user_name=Steve
command=/weather
text=94070
`

I think it would be a good idea to have a corresponding slack model to track all fields that are sent via the post with the exception of '/command' and '/text'.
-'/command' is client specific and doesn't really matter
-'text' is the text following '/command' in a slack message and is what will be massaged and inserted into an EffortSegment record. 